### PR TITLE
Update to support criterion 0.3.3

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -48,12 +48,11 @@ pub struct CThroughput {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "PascalCase")]
 pub struct CEstimates {
     pub mean: CStats,
     pub median: CStats,
     pub median_abs_dev: CStats,
-    pub slope: CStats,
+    pub slope: Option<CStats>,
     pub std_dev: CStats,
 }
 


### PR DESCRIPTION
Fixes: https://github.com/BurntSushi/critcmp/issues/5

Note: This is not backwards compatible with criterion 0.2