### PR TITLE
fix: Casing change in estimates.json

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -48,6 +48,7 @@ pub struct CThroughput {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "PascalCase")]
 pub struct CEstimates {
     pub mean: CStats,
     pub median: CStats,


### PR DESCRIPTION
Found when testing 0.1.4

Example `estimates.json` file
```json
{"Mean":{"confidence_interval":{"confidence_level":0.95,"lower_bound":15.062839156877532,"upper_bound":15.208663743284268},"point_estimate":15.127506967004065,"standard_error":0.037431299050618656},"Median":{"confidence_interval":{"confidence_level":0.95,"lower_bound":14.995805565705473,"upper_bound":15.125709671351526},"point_estimate":15.043049536317922,"standard_error":0.031654749561119355},"MedianAbsDev":{"confidence_interval":{"confidence_level":0.95,"lower_bound":0.15361222549565481,"upper_bound":0.26088330597679193},"point_estimate":0.18977195762737417,"standard_error":0.029364017179265987},"Slope":{"confidence_interval":{"confidence_level":0.95,"lower_bound":15.034964221541623,"upper_bound":15.120168764615318},"point_estimate":15.077513761669776,"standard_error":0.02174824446445178},"StdDev":{"confidence_interval":{"confidence_level":0.95,"lower_bound":0.20116388889046832,"upper_bound":0.5610728492041605},"point_estimate":0.3755759630894315,"standard_error":0.10791673145735754}}
```