### PR TITLE
Fix: If two results differ by less than a nanosecond the wrong one is occasionally marked as best

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -39,7 +39,9 @@ impl Comparison {
             return comp;
         }
 
-        comp.benchmarks.sort_by_key(|b| b.nanoseconds as u64);
+        comp.benchmarks.sort_by(|a, b| {
+            a.nanoseconds.partial_cmp(&b.nanoseconds).unwrap()
+        });
         comp.benchmarks[0].best = true;
 
         let top = comp.benchmarks[0].nanoseconds;


### PR DESCRIPTION
Before the patch:

![image](https://user-images.githubusercontent.com/3736990/114720975-c2fcaa00-9d38-11eb-9736-41ebe4887742.png)

After the patch:

![image](https://user-images.githubusercontent.com/3736990/114721033-d0b22f80-9d38-11eb-9d71-bce30699a15e.png)

The `unwrap()` should not be an issue as Criterion das not store NaN values AFAIK.