### PR TITLE
Add `--nanoseconds` flag

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use termcolor::{self, WriteColor};
 use crate::data::{BaseBenchmarks, Benchmarks};
 use crate::Result;
 
-const TEMPLATE: &'static str = "\
+const TEMPLATE: &str = "\
 {bin} {version}
 {author}
 {about}
@@ -26,7 +26,7 @@ SUBCOMMANDS:
 OPTIONS:
 {unified}";
 
-const ABOUT: &'static str = "
+const ABOUT: &str = "
 critcmp is a tool for comparing benchmark results produced by Criterion.
 
 critcmp works by slurping up all benchmark data from Criterion's target

--- a/src/app.rs
+++ b/src/app.rs
@@ -198,6 +198,10 @@ impl Args {
         self.0.value_of_lossy("export").map(|v| v.into_owned())
     }
 
+    pub fn format_nanoseconds(&self) -> bool {
+        self.0.is_present("nanoseconds")
+    }
+
     pub fn criterion_dir(&self) -> Result<PathBuf> {
         let target_dir = self.target_dir()?;
         let crit_dir = target_dir.join("criterion");
@@ -279,6 +283,9 @@ fn app() -> App<'static, 'static> {
             .help("Show each benchmark comparison as a list. This is useful \
                    when there are many comparisons for each benchmark such \
                    that they no longer fit in a column view."))
+        .arg(Arg::with_name("nanoseconds")
+           .long("nanoseconds")
+           .help("Output nanoseconds instead of converting it by default"))
         .arg(Arg::with_name("filter")
             .long("filter")
             .short("f")

--- a/src/data.rs
+++ b/src/data.rs
@@ -170,13 +170,10 @@ impl Benchmark {
 
         let scale = NANOS_PER_SECOND / self.nanoseconds();
 
-        self.info.throughput.as_ref().and_then(|t| {
-            if let Some(num) = t.bytes {
-                Some(Throughput::Bytes(num as f64 * scale))
-            } else if let Some(num) = t.elements {
-                Some(Throughput::Elements(num as f64 * scale))
-            } else {
-                None
+        self.info.throughput.as_ref().and_then(|t| match t.bytes {
+            Some(num) => Some(Throughput::Bytes(num as f64 * scale)),
+            None => {
+                t.elements.map(|num| Throughput::Elements(num as f64 * scale))
             }
         })
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn try_main() -> Result<()> {
             None => fail!("failed to find baseline '{}'", baseline),
         };
         serde_json::to_writer_pretty(&mut stdout, basedata)?;
-        writeln!(stdout, "")?;
+        writeln!(stdout)?;
         return Ok(());
     }
 
@@ -109,7 +109,7 @@ fn group_by_regex(
             if filter.map_or(false, |re| !re.is_match(name)) {
                 continue;
             }
-            let (bench, cmp) = match benchmark_names(&benchmark, group_by) {
+            let (bench, cmp) = match benchmark_names(benchmark, group_by) {
                 None => continue,
                 Some((bench, cmp)) => (bench, cmp),
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,11 +64,13 @@ fn try_main() -> Result<()> {
         fail!("no benchmark comparisons to show");
     }
 
+    let format_time = !args.format_nanoseconds();
+
     let mut wtr = args.stdout();
     if args.list() {
-        output::rows(&mut wtr, &comps)?;
+        output::rows(&mut wtr, &comps, format_time)?;
     } else {
-        output::columns(&mut wtr, &comps)?;
+        output::columns(&mut wtr, &comps, format_time)?;
     }
     wtr.flush()?;
     Ok(())

--- a/src/output.rs
+++ b/src/output.rs
@@ -32,7 +32,7 @@ impl Comparison {
     pub fn new(name: &str, benchmarks: Vec<Benchmark>) -> Comparison {
         let mut comp = Comparison {
             name: name.to_string(),
-            benchmarks: benchmarks,
+            benchmarks,
             name_to_index: BTreeMap::new(),
         };
         if comp.benchmarks.is_empty() {
@@ -102,14 +102,14 @@ pub fn columns<W: WriteColor>(
     for column in &columns {
         write!(wtr, "\t  {}", column)?;
     }
-    writeln!(wtr, "")?;
+    writeln!(wtr)?;
 
     write_divider(&mut wtr, '-', "group".width())?;
     for column in &columns {
         write!(wtr, "\t  ")?;
         write_divider(&mut wtr, '-', column.width())?;
     }
-    writeln!(wtr, "")?;
+    writeln!(wtr)?;
 
     for group in groups {
         if group.benchmarks.is_empty() {
@@ -142,7 +142,7 @@ pub fn columns<W: WriteColor>(
                 wtr.reset()?;
             }
         }
-        writeln!(wtr, "")?;
+        writeln!(wtr)?;
     }
     Ok(())
 }
@@ -150,7 +150,7 @@ pub fn columns<W: WriteColor>(
 pub fn rows<W: WriteColor>(mut wtr: W, groups: &[Comparison]) -> Result<()> {
     for (i, group) in groups.iter().enumerate() {
         if i > 0 {
-            writeln!(wtr, "")?;
+            writeln!(wtr)?;
         }
         rows_one(&mut wtr, group)?;
     }
@@ -160,7 +160,7 @@ pub fn rows<W: WriteColor>(mut wtr: W, groups: &[Comparison]) -> Result<()> {
 fn rows_one<W: WriteColor>(mut wtr: W, group: &Comparison) -> Result<()> {
     writeln!(wtr, "{}", group.name)?;
     write_divider(&mut wtr, '-', group.name.width())?;
-    writeln!(wtr, "")?;
+    writeln!(wtr)?;
 
     if group.benchmarks.is_empty() {
         writeln!(wtr, "NOTHING TO SHOW")?;


### PR DESCRIPTION
The PR adds `--nanoseconds` flag to not format nanoseconds.
It's allows easier post processing of `critcmp` data.

Specifically it allows comparisons of the values, without converting them to some base.

The flag name is not good to be honest.

An example of an output

```
group                                    base                                   new
-----                                    ----                                   ---
test_const_table/cli_table/1             1.00          2301.1        ? ?/sec    1.00          2301.1        ? ?/sec
test_const_table/cli_table/128           1.00       8127398.6        ? ?/sec    1.00       8127398.6        ? ?/sec
test_const_table/cli_table/32            1.00        596568.5        ? ?/sec    1.00        596568.5        ? ?/sec
test_const_table/cli_table/512           1.00     153072670.4        ? ?/sec    1.00     153072670.4        ? ?/sec
test_const_table/cli_table/8             1.00         47750.0        ? ?/sec    1.00         47750.0        ? ?/sec
test_const_table/comfy_table/1           1.00          5000.6        ? ?/sec    1.00          5000.6        ? ?/sec
test_const_table/comfy_table/128         1.00      11137977.0        ? ?/sec    1.00      11137977.0        ? ?/sec
test_const_table/comfy_table/32          1.00        771600.9        ? ?/sec    1.00        771600.9        ? ?/sec
```
